### PR TITLE
fix: download links

### DIFF
--- a/tab_download.md
+++ b/tab_download.md
@@ -43,18 +43,18 @@ tags: downloads-tag
 * [Slide - Presented by Keith Turpin on OWASP AppSec USA 2010][appsecusa10]
 * [XLS Feedback Spreadsheet][fbsh]
 
-[br13pdf]: https://www.owasp.org/images/b/b3/OWASP_SCP_v1.3_pt-BR.pdf
-[en1pdf]: https://www.owasp.org/images/4/45/OWASP_SCP_Quick_Reference_Guide_v1.pdf
-[en1doc]: www.owasp.org/images/1/10/OWASP_SCP_Quick_Reference_Guide_v1.doc
+[br13pdf]: https://owasp.org/www-pdf-archive/OWASP_SCP_v1.3_pt-BR.pdf
+[en1pdf]: https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v1.pdf
+[en1doc]: https://wiki.owasp.org/images/1/10/OWASP_SCP_Quick_Reference_Guide_v1.doc
 [en11pdf]: http://www.owasp.org/images/2/2f/OWASP_SCP_Quick_Reference_Guide_v1-1b.pdf
-[en11doc]: http://www.owasp.org/images/0/0b/OWASP_SCP_Quick_Reference_Guide_v1-1b.doc
-[en2pdf]: https://www.owasp.org/images/0/08/OWASP_SCP_Quick_Reference_Guide_v2.pdf
-[en2doc]: https://www.owasp.org/images/a/ac/OWASP_SCP_Quick_Reference_Guide_v2.doc
-[kor2pdf]: https://www.owasp.org/images/8/8e/2011%EB%85%846%EC%9B%94_OWASP_%EC%8B%9C%ED%81%90%EC%96%B4%EC%BD%94%EB%94%A9%EA%B7%9C%EC%B9%99_v2_KOR.pdf
-[pt13pdf]: https://www.owasp.org/images/6/6d/OWASP_SCP_v1.3_pt-PT.pdf
-[es1doc]: https://www.owasp.org/images/c/c8/OWASP_SCP_Quick_Reference_Guide_SPA.doc
-[cn1pdf]: https://www.owasp.org/images/7/73/OWASP_SCP_Quick_Reference_Guide_%28Chinese%29.pdf
-[Project Pamphlet]: http://www.owasp.org/images/3/35/Flyer_Secure_Coding_Practices_Quick_Reference_Guide_V2.pdf
-[Project Presentation]: https://www.owasp.org/images/f/fd/Secure_Coding_Practices_Quick_Ref_6.ppt
-[appsecusa10]: http://www.owasp.org/images/5/54/Secure_Coding_Practices_Quick_Ref_5.ppt
-[fbsh]: http://www.owasp.org/images/6/64/SCP-QRG_Revisions_History.xls
+[en11doc]: http://wiki.owasp.org/images/0/0b/OWASP_SCP_Quick_Reference_Guide_v1-1b.doc
+[en2pdf]: https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf
+[en2doc]: https://wiki.owasp.org/images/a/ac/OWASP_SCP_Quick_Reference_Guide_v2.doc
+[kor2pdf]: https://owasp.org/www-pdf-archive//2011%EB%85%846%EC%9B%94_OWASP_%EC%8B%9C%ED%81%90%EC%96%B4%EC%BD%94%EB%94%A9%EA%B7%9C%EC%B9%99_v2_KOR.pdf
+[pt13pdf]: https://owasp.org/www-pdf-archive/OWASP_SCP_v1.3_pt-PT.pdf
+[es1doc]: https://wiki.owasp.org/images/c/c8/OWASP_SCP_Quick_Reference_Guide_SPA.doc
+[cn1pdf]: https://owasp.org/www-pdf-archive//OWASP_SCP_Quick_Reference_Guide_(Chinese).pdf
+[Project Pamphlet]: https://owasp.org/www-pdf-archive/Flyer_Secure_Coding_Practices_Quick_Reference_Guide_V2.pdf
+[Project Presentation]: https://wiki.owasp.org/images/f/fd/Secure_Coding_Practices_Quick_Ref_6.ppt
+[appsecusa10]: https://wiki.owasp.org/images/5/54/Secure_Coding_Practices_Quick_Ref_5.ppt
+[fbsh]: https://wiki.owasp.org/images/6/64/SCP-QRG_Revisions_History.xls


### PR DESCRIPTION
PDFs are now downloaded from OWASP PDF archive location. Other formats such as DOC, PPT, and XLS are downloaded from retired OWASP's wiki.