### PR TITLE
Re-issue all languages to version 2.0.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 __pycache__
 env
+.project
 .vscode
 _site/
+

--- a/README.md
+++ b/README.md
@@ -9,8 +9,15 @@ Create issues on this repository **only** for content hosted under this subfolde
 For issues or suggestions related to SCP Quick-reference Guide itself, please contact one of the leaders.
 
 ### Project leaders
+
 * [Keith Turpin](mailto:Keith.Turpin@owasp.org)
 * [Jon Gadsden](mailto:jon.gadsden@owasp.org)
 
-[www-project]: https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/
+### Editor
+
+* [Jon Gadsden][jon]
+
+[keith]: mailto:Keith.Turpin@owasp.org
+[jon]: mailto:jon.gadsden@owasp.org
 [original]: https://wiki.owasp.org/index.php/OWASP_Secure_Coding_Practices_-_Quick_Reference_Guide
+[www-project]: https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/

--- a/index.md
+++ b/index.md
@@ -27,6 +27,28 @@ to help development teams quickly understand secure coding practices.
 * Links to useful resources
 * Glossary of important terminology
 
+Key areas covered in the checklist :
+
+* Input Validation
+* Output Encoding
+* Authentication and Password Management
+* Session Management
+* Access Control
+* Cryptographic Practices
+* Error Handling and Logging
+* Data Protection
+* Communication Security
+* System Configuration
+* Database Security
+* File Management
+* Memory Management
+* General Coding Practices
+
+Originally developed for use inside The Boeing Company, in July 2010 Boeing
+assigned copyright to OWASP under the leadership of [Keith Turpin][keith].
+This guide has been translated into several languages and has been reissued
+and kept up to date by various OWASP contributors and chapters.
+
 -----
 
 #### Feedback and Participation
@@ -35,16 +57,16 @@ We hope you find the OWASP Secure Coding Practices Quick Reference Guide Project
 useful. We welcome additions and corrections to the existing documents,
 and the [project github repo][github] is always looking for collaborators.
 
-Please contribute to this project by adding your comments, questions,
+Please contribute by adding your comments, questions,
 and suggestions using the project github [change request][change] form.
+You can also contact the editor [Jon Gadsden][jon] for advice on this project.
 
 #### Related Projects
 
-* [Go programming language secure coding practices guide][owaspgoscp], based on the OWASP
-  Secure Coding Practices
+* Go programming language [secure coding practices guide][go-scp]
 
 [keith]: mailto:Keith.Turpin@owasp.org
 [jon]: mailto:jon.gadsden@owasp.org
 [change]: https://github.com/OWASP/secure-coding-practices-quick-reference-guide/issues/new?assignees=&labels=enhancement&template=request.md&title=
 [github]: https://github.com/OWASP/secure-coding-practices-quick-reference-guide
-[owaspgoscp]: https://owasp.org/www-project-go-secure-coding-practices-guide/
+[go-scp]: https://owasp.org/www-project-go-secure-coding-practices-guide/

--- a/info.md
+++ b/info.md
@@ -5,23 +5,22 @@
 [![Builders][builders-logo]][builders]
 [![Defenders][defenders-logo]][defenders]
 
+[![CC BY-SA 3.0][license-logo]{:width="175px"}][license]
+
 ### Code Repository
-[Repository][repo]
-[Issue Tracker][issues]
 
-### Licence
-
-[![CC BY-SA 3.0][license-logo]][license]
+* [Repository][repo]
+* [Issue Tracker][issues]
 
 ### Downloads
 
-* [v2 (current release)][v2PDF]
-* [v1.1 (last reviewed)][v11PDF]
+* [latest release][v201PDF]
+* [version 1.1][v11PDF]
 * [Other versions/languages][ovl]
 
 ### Related Projects
 
-* [OWASP Go Secure Coding Practices Guide][owasp-go-scp]
+[OWASP Go Secure Coding Practices Guide][go-scp]
 
 [doc-proj-logo]: assets/images/common/owasp_documentation_project.svg
 [builders]: https://www.owasp.org/index.php/Builders
@@ -34,7 +33,7 @@
 [license]: http://creativecommons.org/licenses/by-sa/3.0/
 [license-logo]: assets/images/by-sa.svg
 [repo]: https://github.com/OWASP/secure-coding-practices-quick-reference-guide
-[v2PDF]: https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf
+[v201PDF]: 
 [v11PDF]: https://www.owasp.org/images/2/2f/OWASP_SCP_Quick_Reference_Guide_v1-1b.pdf
-[ovl]: https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/#div-download
-[owasp-go-scp]: https://owasp.org/www-project-go-secure-coding-practices-guide/
+[ovl]: #div-download
+[go-scp]: https://owasp.org/www-project-go-secure-coding-practices-guide/

--- a/info.md
+++ b/info.md
@@ -14,7 +14,7 @@
 
 ### Downloads
 
-* [latest release][v201PDF]
+* [latest release][v201]
 * [version 1.1][v11PDF]
 * [Other versions/languages][ovl]
 
@@ -33,7 +33,7 @@
 [license]: http://creativecommons.org/licenses/by-sa/3.0/
 [license-logo]: assets/images/by-sa.svg
 [repo]: https://github.com/OWASP/secure-coding-practices-quick-reference-guide
-[v201PDF]: 
+[v201]: https://github.com/OWASP/secure-coding-practices-quick-reference-guide/releases/tag/v2.0.1
 [v11PDF]: https://www.owasp.org/images/2/2f/OWASP_SCP_Quick_Reference_Guide_v1-1b.pdf
 [ovl]: #div-download
 [go-scp]: https://owasp.org/www-project-go-secure-coding-practices-guide/

--- a/leaders.md
+++ b/leaders.md
@@ -3,5 +3,9 @@
 * [Keith Turpin][keith]
 * [Jon Gadsden][jon]
 
+### Editor
+
+* [Jon Gadsden][jon]
+
 [keith]: mailto:Keith.Turpin@owasp.org
 [jon]: mailto:jon.gadsden@owasp.org

--- a/tab_download.md
+++ b/tab_download.md
@@ -6,12 +6,23 @@ order: 1
 tags: downloads
 ---
 
-## v2 (current release)
+## v2.0.1 (current release)
+
+| Language | PDF | eBook |
+| -------- | :-: |
+| Brazilian | [download][br201pdf] | [download eBook][br201ebook] |
+| Chinese | [download][cn201pdf] | [download eBook][cn201ebook] |
+| English | [download][en201pdf] | [download eBook][en201ebook] |
+| Korean | [download][ko201pdf] | [download eBook][ko201ebook] |
+| Portuguese | [download][pt201pdf] | [download eBook][pt201ebook] |
+| Spanish | [download][es201pdf] | [download eBook][es201ebook] |
+
+## v2.0
 
 | Language | PDF | DOC |
 | -------- | :-: | :-: |
-| English | [download][en2pdf] | [download][en2doc] |
-| Korean | [download][kor2pdf] | - |
+| English | [download][en20pdf] | [download][en20doc] |
+| Korean | [download][ko20pdf] | - |
 
 ## v1.3
 
@@ -30,31 +41,42 @@ tags: downloads
 
 | Language | PDF | DOC |
 | -------- | :-: | :-: |
-| Chinese | [download][cn1pdf] | - |
-| English | [download][en1pdf] | [download][en1doc] |
-| Spanish | - | [download][es1doc] |
+| Chinese | [download][cn10pdf] | - |
+| English | [download][en10pdf] | [download][en10doc] |
+| Spanish | - | [download][es10doc] |
 
 -----
 
 ## other downloads
 
-* [Project Pamphlet]
-* [Project Presentation]
-* [Slide - Presented by Keith Turpin on OWASP AppSec USA 2010][appsecusa10]
-* [XLS Feedback Spreadsheet][fbsh]
+* [Project Pamphlet][pamphlet]
+* [Project Presentation][presentation]
+* [Slide deck][appsecusa10]- Presented by Keith Turpin on OWASP AppSec USA 2010
+* [Archive XLS Feedback Spreadsheet][fbsh]
 
 [br13pdf]: https://owasp.org/www-pdf-archive/OWASP_SCP_v1.3_pt-BR.pdf
-[en1pdf]: https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v1.pdf
-[en1doc]: https://wiki.owasp.org/images/1/10/OWASP_SCP_Quick_Reference_Guide_v1.doc
+[cn10pdf]: https://owasp.org/www-pdf-archive//OWASP_SCP_Quick_Reference_Guide_(Chinese).pdf
+[cn201ebook]: 
+[cn201pdf]: 
+[en10pdf]: https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v1.pdf
+[en10doc]: https://wiki.owasp.org/images/1/10/OWASP_SCP_Quick_Reference_Guide_v1.doc
 [en11pdf]: http://www.owasp.org/images/2/2f/OWASP_SCP_Quick_Reference_Guide_v1-1b.pdf
 [en11doc]: http://wiki.owasp.org/images/0/0b/OWASP_SCP_Quick_Reference_Guide_v1-1b.doc
-[en2pdf]: https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf
-[en2doc]: https://wiki.owasp.org/images/a/ac/OWASP_SCP_Quick_Reference_Guide_v2.doc
-[kor2pdf]: https://owasp.org/www-pdf-archive//2011%EB%85%846%EC%9B%94_OWASP_%EC%8B%9C%ED%81%90%EC%96%B4%EC%BD%94%EB%94%A9%EA%B7%9C%EC%B9%99_v2_KOR.pdf
+[en20pdf]: https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf
+[en20doc]: https://wiki.owasp.org/images/a/ac/OWASP_SCP_Quick_Reference_Guide_v2.doc
+[en201ebook]: 
+[en201pdf]: 
+[es10doc]: https://wiki.owasp.org/images/c/c8/OWASP_SCP_Quick_Reference_Guide_SPA.doc
+[es201ebook]: 
+[es201pdf]: 
+[ko20pdf]: https://owasp.org/www-pdf-archive//2011%EB%85%846%EC%9B%94_OWASP_%EC%8B%9C%ED%81%90%EC%96%B4%EC%BD%94%EB%94%A9%EA%B7%9C%EC%B9%99_v2_KOR.pdf
+[ko201ebook]: 
+[ko201pdf]: 
 [pt13pdf]: https://owasp.org/www-pdf-archive/OWASP_SCP_v1.3_pt-PT.pdf
-[es1doc]: https://wiki.owasp.org/images/c/c8/OWASP_SCP_Quick_Reference_Guide_SPA.doc
-[cn1pdf]: https://owasp.org/www-pdf-archive//OWASP_SCP_Quick_Reference_Guide_(Chinese).pdf
-[Project Pamphlet]: https://owasp.org/www-pdf-archive/Flyer_Secure_Coding_Practices_Quick_Reference_Guide_V2.pdf
-[Project Presentation]: https://wiki.owasp.org/images/f/fd/Secure_Coding_Practices_Quick_Ref_6.ppt
+[pt201ebook]: 
+[pt201pdf]: 
+
+[pamphlet]: https://owasp.org/www-pdf-archive/Flyer_Secure_Coding_Practices_Quick_Reference_Guide_V2.pdf
+[presentation]: https://wiki.owasp.org/images/f/fd/Secure_Coding_Practices_Quick_Ref_6.ppt
 [appsecusa10]: https://wiki.owasp.org/images/5/54/Secure_Coding_Practices_Quick_Ref_5.ppt
 [fbsh]: https://wiki.owasp.org/images/6/64/SCP-QRG_Revisions_History.xls

--- a/tab_download.md
+++ b/tab_download.md
@@ -54,27 +54,29 @@ tags: downloads
 * [Slide deck][appsecusa10]- Presented by Keith Turpin on OWASP AppSec USA 2010
 * [Archive XLS Feedback Spreadsheet][fbsh]
 
+[br201ebook]: https://github.com/OWASP/secure-coding-practices-quick-reference-guide/releases/download/v2.0.1/OWASP_SCP_Quick_Reference_Guide.pt-BR.epub
+[br201pdf]: https://github.com/OWASP/secure-coding-practices-quick-reference-guide/releases/download/v2.0.1/OWASP_SCP_Quick_Reference_Guide.pt-BR.pdf
 [br13pdf]: https://owasp.org/www-pdf-archive/OWASP_SCP_v1.3_pt-BR.pdf
 [cn10pdf]: https://owasp.org/www-pdf-archive//OWASP_SCP_Quick_Reference_Guide_(Chinese).pdf
-[cn201ebook]: 
-[cn201pdf]: 
+[cn201ebook]: https://github.com/OWASP/secure-coding-practices-quick-reference-guide/releases/download/v2.0.1/OWASP_SCP_Quick_Reference_Guide.zh-CN.epub
+[cn201pdf]: https://github.com/OWASP/secure-coding-practices-quick-reference-guide/releases/download/v2.0.1/OWASP_SCP_Quick_Reference_Guide.zh-CN.pdf
 [en10pdf]: https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v1.pdf
 [en10doc]: https://wiki.owasp.org/images/1/10/OWASP_SCP_Quick_Reference_Guide_v1.doc
 [en11pdf]: http://www.owasp.org/images/2/2f/OWASP_SCP_Quick_Reference_Guide_v1-1b.pdf
 [en11doc]: http://wiki.owasp.org/images/0/0b/OWASP_SCP_Quick_Reference_Guide_v1-1b.doc
 [en20pdf]: https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf
 [en20doc]: https://wiki.owasp.org/images/a/ac/OWASP_SCP_Quick_Reference_Guide_v2.doc
-[en201ebook]: 
-[en201pdf]: 
+[en201ebook]: https://github.com/OWASP/secure-coding-practices-quick-reference-guide/releases/download/v2.0.1/OWASP_SCP_Quick_Reference_Guide.en-US.epub
+[en201pdf]: https://github.com/OWASP/secure-coding-practices-quick-reference-guide/releases/download/v2.0.1/OWASP_SCP_Quick_Reference_Guide.en-US.pdf
 [es10doc]: https://wiki.owasp.org/images/c/c8/OWASP_SCP_Quick_Reference_Guide_SPA.doc
-[es201ebook]: 
-[es201pdf]: 
+[es201ebook]: https://github.com/OWASP/secure-coding-practices-quick-reference-guide/releases/download/v2.0.1/OWASP_SCP_Quick_Reference_Guide.es-UY.epub
+[es201pdf]: https://github.com/OWASP/secure-coding-practices-quick-reference-guide/releases/download/v2.0.1/OWASP_SCP_Quick_Reference_Guide.es-UY.pdf
 [ko20pdf]: https://owasp.org/www-pdf-archive//2011%EB%85%846%EC%9B%94_OWASP_%EC%8B%9C%ED%81%90%EC%96%B4%EC%BD%94%EB%94%A9%EA%B7%9C%EC%B9%99_v2_KOR.pdf
-[ko201ebook]: 
-[ko201pdf]: 
+[ko201ebook]: https://github.com/OWASP/secure-coding-practices-quick-reference-guide/releases/download/v2.0.1/OWASP_SCP_Quick_Reference_Guide.ko-KR.epub
+[ko201pdf]: https://github.com/OWASP/secure-coding-practices-quick-reference-guide/releases/download/v2.0.1/OWASP_SCP_Quick_Reference_Guide.ko-KR.pdf
 [pt13pdf]: https://owasp.org/www-pdf-archive/OWASP_SCP_v1.3_pt-PT.pdf
-[pt201ebook]: 
-[pt201pdf]: 
+[pt201ebook]: https://github.com/OWASP/secure-coding-practices-quick-reference-guide/releases/download/v2.0.1/OWASP_SCP_Quick_Reference_Guide.pt-PT.epub
+[pt201pdf]: https://github.com/OWASP/secure-coding-practices-quick-reference-guide/releases/download/v2.0.1/OWASP_SCP_Quick_Reference_Guide.pt-PT.pdf
 
 [pamphlet]: https://owasp.org/www-pdf-archive/Flyer_Secure_Coding_Practices_Quick_Reference_Guide_V2.pdf
 [presentation]: https://wiki.owasp.org/images/f/fd/Secure_Coding_Practices_Quick_Ref_6.ppt


### PR DESCRIPTION
This re-issues all languages to version 2.0.1:

Translations are provided for Brazilian, Chinese, Korean, Portuguese and Spanish. Some of the translations are based on earlier versions and we expect that these translations will be updated in early 2023 - depending on the support and response of the community.

Brazilian: OWASP_SCP_Quick_Reference_Guide.pt-BR.pdf
ebook: OWASP_SCP_Quick_Reference_Guide.pt-BR.epub

Chinese: OWASP_SCP_Quick_Reference_Guide.zh-CN.pdf
ebook: OWASP_SCP_Quick_Reference_Guide.zh-CN.epub

English: OWASP_SCP_Quick_Reference_Guide.en-US.pdf
ebook: OWASP_SCP_Quick_Reference_Guide.en-US.epub

Korean: OWASP_SCP_Quick_Reference_Guide.ko-KR.pdf
ebook: OWASP_SCP_Quick_Reference_Guide.ko-KR.epub

Portuguese: OWASP_SCP_Quick_Reference_Guide.pt-PT.pdf
ebook: OWASP_SCP_Quick_Reference_Guide.pt-PT.epub

Spanish: OWASP_SCP_Quick_Reference_Guide.es-UY.pdf
ebook: OWASP_SCP_Quick_Reference_Guide.es-UY.epub